### PR TITLE
feat: 🎸 學生訂單列表新增重新付款按鈕

### DIFF
--- a/src/pages/student/order-list-page/OrderListPage.tsx
+++ b/src/pages/student/order-list-page/OrderListPage.tsx
@@ -2,17 +2,55 @@ import { useEffect } from "react";
 import { TableCell, TableHead } from "@/components/ui/table";
 import { TableWithPagination } from "@/components/common/TableWithPagination";
 import { useOrderListStore } from "./orderListStore";
+import { Button } from "@/components/ui/button";
+import { useDialogStore } from "@/stores/commonDialogStore";
+import axios from "axios";
 
 export default function OrderListPage() {
-  const { orderList, pagination, fetchOrder } = useOrderListStore();
+  const { orderList, pagination, fetchOrder, checkoutEcpay } = useOrderListStore();
+  const { showCommonDialog } = useDialogStore();
 
   const tableColumn = [
     { label: "產品名稱", key: "title" },
     { label: "價格", key: "orderPrice" },
     { label: "購買日期", key: "paidAt" },
     { label: "操作紀錄", key: "status" },
+    { label: "重新付款", key: "action" },
   ];
 
+  const handleRepay = async (orderId: string) => {
+    try {
+      const response = await checkoutEcpay(orderId);
+      
+      const wrapper = document.createElement("div");
+      wrapper.innerHTML = response;
+      const form = wrapper.querySelector("form");
+
+      if (form) {
+        document.body.appendChild(form);
+        form.submit();
+      } else {
+        showCommonDialog({
+          title: "發生錯誤",
+          description: "未取得綠界付款表單，請稍後再試。",
+        });
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.data) {
+        const { status, message } = error.response.data;
+        showCommonDialog({
+          title: status,
+          description: message,
+        });
+      } else {
+        showCommonDialog({
+          title: "Error",
+          description: "Something went wrong. Please try again later.",
+        });
+      }
+    }
+  };
+  
   useEffect(() => {
     fetchOrder(pagination.currentPage, 10);
   }, []);
@@ -41,6 +79,17 @@ export default function OrderListPage() {
                 <TableCell>{order.orderPrice}</TableCell>
                 <TableCell>{order.paidAt}</TableCell>
                 <TableCell>{order.status}</TableCell>
+                <TableCell>
+                  {order.status === "待付款" && (
+                    <Button 
+                      onClick={() => handleRepay(order.id)}
+                      variant="default"
+                      size="sm"
+                    >
+                      重新付款
+                    </Button>
+                  )}
+                </TableCell>
               </>
             )}
           />

--- a/src/pages/student/order-list-page/orderListStore.ts
+++ b/src/pages/student/order-list-page/orderListStore.ts
@@ -4,6 +4,7 @@ import { Order } from "./types";
 import { Pagination } from "@/services/types";
 import { fetchOrderList } from "./order-list.service";
 import { DEFAULT_PAGINATION } from "@/lib/constants";
+import { checkoutEcpay } from "../order-page/service/order.service";
 
 interface OrderListPageState {
   orderList: Order[];
@@ -14,11 +15,14 @@ interface OrderListPageState {
 
 interface OrderListPageAction {
   fetchOrder: (page: number, pageSize: number) => void;
+  checkoutEcpay: (orderId: string) => Promise<string>;
   setIsShowDialog: (isShowDialog: boolean) => void;
   resetStore: () => void;
 }
 
-export const useOrderListStore = create<OrderListPageState & OrderListPageAction>()(
+export const useOrderListStore = create<
+  OrderListPageState & OrderListPageAction
+>()(
   immer((set) => ({
     orderList: [],
     pagination: DEFAULT_PAGINATION,
@@ -40,6 +44,19 @@ export const useOrderListStore = create<OrderListPageState & OrderListPageAction
         set((state) => {
           state.isLoading = false;
         });
+      }
+    },
+    checkoutEcpay: async (orderId: string) => {
+      // 開始載入
+      set((state) => {
+        state.isLoading = true;
+      });
+      try {
+        const ecpayFormString = await checkoutEcpay(orderId);
+        return ecpayFormString;
+      } catch (error) {
+        console.error("Failed to checkoutOrder", error);
+        throw error;
       }
     },
     setIsShowDialog: (isShowDialog) => {


### PR DESCRIPTION
### ✨ 新功能內容
訂單列表新增重新付款功能

### 📌 背景與目的

防止使用跳轉綠界頁面因操作問題，無法完成結帳，
故設計此按鈕，可以重新產生綠界付款畫面

---

### ✅ 自我測試檢查
- [x] 功能流程跑通
- [ ] 與設計稿符合（若有）
- [ ] API 串接正確，資料更新正常
- [x] 無多餘 console.log 或測試代碼

---

### 🔍 希望 Reviewer 協助確認：

排版及按鈕是否可以更優化？

---

### 🧪 測試方式
> 提供測試路徑與方式，讓 Reviewer 可以快速驗證：

登入學生身份後進入 \購買頁面，
找到重新付款按鈕，
點擊後正常跳轉至綠界。


P.S.付款完成導回頁面因為後端預設是render版本路由，可以先行於render網頁登入同一帳號，就可以正常跳轉
若使用本地端測試，因綠界call back無法回傳本地，付款成功不會更新訂單狀態，屬於正常現象～

---

### 🙋 Reviewer 指派


---

### 📅 備註
- 週末有空請幫忙 review，先感謝 🙇‍♀️
