### PR TITLE
feat: 🎸 結帳完成頁面增加按鈕

### DIFF
--- a/src/lib/priceHelper.ts
+++ b/src/lib/priceHelper.ts
@@ -12,7 +12,7 @@ import { CouponType } from "@/lib/enum";
  * formatPrice(null);  // ""
  */
 export const formatPrice = (price?: number | null) =>
-    price != null ? `NT$${price.toLocaleString()}` : "";
+  price != null ? `NT$${price.toLocaleString()}` : "";
 
 /**
  * 計算百分比折扣後的價格字串（含千分位逗號）
@@ -21,11 +21,11 @@ export const formatPrice = (price?: number | null) =>
  * @returns {string} 折扣金額（字串格式，含千分位）
  */
 export const calculatePercentageDiscount = (
-    originalPrice: number,
-    percent: string
+  originalPrice: number,
+  percent: string
 ): string => {
-    const discountPrice = originalPrice * (Number(percent) / 100);
-    return Math.round(discountPrice).toLocaleString();
+  const discountPrice = originalPrice * (Number(percent) / 100);
+  return Math.round(discountPrice).toLocaleString();
 };
 
 /**
@@ -35,20 +35,20 @@ export const calculatePercentageDiscount = (
  * @returns {string} 格式化後的折扣字串（如 "-NT$1,000" 或 "-NT500"）
  */
 export const formatCouponDiscount = (
-    originalPrice: number | null,
-    coupon: CouponInfo
+  originalPrice: number | null,
+  coupon: CouponInfo
 ): string => {
-    if (!coupon?.value || !coupon.type || !originalPrice) return "";
+  if (!coupon?.value || !coupon.type || !originalPrice) return "";
 
-    if (coupon.type === CouponType.FIXED) {
-        return `-NT$${Number(coupon.value).toLocaleString()}`;
-    }
+  if (coupon.type === CouponType.FIXED) {
+    return `-NT$${Number(coupon.value).toLocaleString()}`;
+  }
 
-    if (coupon.type === CouponType.PERCENTAGE) {
-        return `-NT${calculatePercentageDiscount(originalPrice, coupon.value)}`;
-    }
+  if (coupon.type === CouponType.PERCENTAGE) {
+    return `-NT${calculatePercentageDiscount(originalPrice, coupon.value)}`;
+  }
 
-    return "";
+  return "";
 };
 
 /**
@@ -57,12 +57,12 @@ export const formatCouponDiscount = (
  * @returns {string} 折扣標籤字串
  */
 export const handleCouponTypeLabel = (couponData: CouponInfo) => {
-    const { type, value } = couponData || {};
-    if (type == "fix") {
-        return `(折扣${value}元)`;
-    } else if (type == "percentage") {
-        return `(折扣${parseInt(value)}%)`;
-    } else {
-        return "";
-    }
+  const { type, value, couponName } = couponData || {};
+  if (type == "fixed") {
+    return `${couponName} (折扣${value}元)`;
+  } else if (type == "percentage") {
+    return `${couponName} (折扣${parseInt(value)}%)`;
+  } else {
+    return "";
+  }
 };

--- a/src/lib/priceHelper.ts
+++ b/src/lib/priceHelper.ts
@@ -59,7 +59,7 @@ export const formatCouponDiscount = (
 export const handleCouponTypeLabel = (couponData: CouponInfo) => {
   const { type, value, couponName } = couponData || {};
   if (type == "fixed") {
-    return `${couponName} (折扣${value}元)`;
+    return `${couponName} (折扣${Math.floor(Number(value))}元)`;
   } else if (type == "percentage") {
     return `${couponName} (折扣${parseInt(value)}%)`;
   } else {

--- a/src/pages/student/checkout-page/CheckoutPage.tsx
+++ b/src/pages/student/checkout-page/CheckoutPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useOrderStore } from "../order-page/store/orderStore";
+import { useOrderListStore } from "../order-list-page/orderListStore";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { OrderStatusBadge } from "@/pages/student/order-page/components/OrderStatusBadge";
 import LOGO from "@/components/common/LOGO";
@@ -9,18 +10,158 @@ import {
   formatPrice,
   handleCouponTypeLabel,
 } from "@/lib/priceHelper";
-import React from "@/assets/homepage/react-course-card.jpg";
+import { Button } from "@/components/ui/button";
+import { CLIENT_ROUTES } from "@/app/route-path";
+import axios from "axios";
+import { useDialogStore } from "@/stores/commonDialogStore";
 
 const CheckoutPage = () => {
   const { orderId } = useParams();
-
-  const { orderData, courseData, couponData, fetchOrder } = useOrderStore();
+  const navigate = useNavigate();
+  const { showCommonDialog } = useDialogStore();
+  const { checkoutEcpay } = useOrderListStore();
+  const { orderData, courseData, couponData, fetchOrder,createOrderPreview } = useOrderStore();
+  
 
   useEffect(() => {
     if (orderId) {
       fetchOrder(orderId);
     }
   }, [orderId]);
+
+  // 繼續購買：跳轉到首頁
+  const handleBackToHome = () => {
+    navigate(CLIENT_ROUTES.HOME);
+  };
+
+  // 開始觀看 : 跳轉到我的學習頁面
+  const handleStartWatching = () => {
+    navigate(CLIENT_ROUTES.MY_LEARNING);
+  };
+
+  // 重新下單: 跳轉到訂單預覽頁面 
+  const handleRebuy = async() => {
+    try {
+      
+
+      navigate(`/order/${courseData.id}`); 
+      const reqData = {
+        courseId: courseData.id,
+        couponId: "",
+      };
+      
+      await createOrderPreview(reqData);
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.data) {
+        const { status, message } = error.response.data;
+        showCommonDialog({
+          title: status,
+          description: message,
+        });
+      } else {
+        // 非 Axios 的錯誤處理
+        showCommonDialog({
+          title: "Error",
+          description: "Something went wrong. Please try again later.",
+        });
+      }
+    }
+  };
+  
+  // 重新付款 : 跳轉到綠界付款頁面
+  const handleRepay = async (orderId: string) => {
+    try {
+      const response = await checkoutEcpay(orderId);
+      
+      const wrapper = document.createElement("div");
+      wrapper.innerHTML = response;
+      const form = wrapper.querySelector("form");
+
+      if (form) {
+        document.body.appendChild(form);
+        form.submit();
+      } else {
+        showCommonDialog({
+          title: "發生錯誤",
+          description: "未取得綠界付款表單，請稍後再試。",
+        });
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.data) {
+        const { status, message } = error.response.data;
+        showCommonDialog({
+          title: status,
+          description: message,
+        });
+      } else {
+        showCommonDialog({
+          title: "Error",
+          description: "Something went wrong. Please try again later.",
+        });
+      }
+    }
+  };
+
+  
+  // 處理根據訂單狀態渲染不同的按鈕
+  const renderActionButtons = () => {
+    // 左邊的按鈕 - 固定是回到課程頁面
+    const leftButton = (
+      <Button 
+        variant="default" 
+        className="px-4 py-2 h-9 text-sm bg-gray-600 hover:bg-gray-700 w-[30%] text-white"
+        onClick={handleBackToHome}
+      >
+        繼續購買
+      </Button>
+    );
+    
+    // 右邊的按鈕 - 根據訂單狀態變化
+    let rightButton;
+    
+    switch (orderData.status) {
+      case 'paid':
+        rightButton = (
+          <Button 
+            variant="default" 
+            className="px-2 py-2 h-9 text-sm bg-orange-600 hover:bg-orange-700 w-[30%] text-white"
+            onClick={handleStartWatching}
+          >
+            開始觀看
+          </Button>
+        );
+        break;
+      case 'failed':
+        rightButton = (
+          <Button 
+            variant="default" 
+            className="px-4 py-2 h-9 text-sm bg-orange-500 hover:bg-orange-600 w-[30%] text-white"
+            onClick={handleRebuy}
+          >
+            重新下單
+          </Button>
+        );
+        break;
+      case 'pending':
+        rightButton = (
+          <Button 
+            variant="default" 
+            className="px-4 py-2 h-9 text-sm bg-orange-500 hover:bg-orange-600 w-[30%] text-white"
+            onClick={() => handleRepay(orderData.id)}
+          >
+            重新付款
+          </Button>
+        );
+        break;
+    }
+    
+    return (
+      <div className="flex justify-end gap-2 mt-2">
+        {leftButton}
+        {rightButton}
+      </div>
+    );
+  };
 
   return (
     <div className="bg-slate-100 px-4 pt-6 pb-4 md:px-80 md:py-12">
@@ -34,7 +175,7 @@ const CheckoutPage = () => {
           </CardHeader>
           <CardContent className="border-b">
             <div className="grid grid-cols-2 gap-4 p-4 md:py-6">
-              <img src={React} className="rounded-xl" alt="react" />
+              <img src= {courseData.cover_url} className="rounded-xl" alt="課程縮圖" />
               <div className="text">
                 <h2 className="font-medium text-xl md:text-2xl mb-4">
                   {courseData.title}
@@ -59,10 +200,11 @@ const CheckoutPage = () => {
             </div>
           </CardContent>
           <CardContent>
-            <p className="flex justify-between font-bold text-base py-6">
+            <p className="flex justify-between font-bold text-base py-3">
               <span>總計</span>
               <span>{formatPrice(orderData.orderPrice)}</span>
             </p>
+            {renderActionButtons()}
           </CardContent>
         </Card>
       </div>

--- a/src/pages/student/order-list-page/OrderListPage.tsx
+++ b/src/pages/student/order-list-page/OrderListPage.tsx
@@ -76,7 +76,7 @@ export default function OrderListPage() {
             renderRow={(order) => (
               <>
                 <TableCell>{order.title}</TableCell>
-                <TableCell>{order.orderPrice}</TableCell>
+                <TableCell>{Math.floor(order.orderPrice)}</TableCell>
                 <TableCell>{order.paidAt}</TableCell>
                 <TableCell>{order.status}</TableCell>
                 <TableCell>

--- a/src/pages/student/order-page/constants/initialData.ts
+++ b/src/pages/student/order-page/constants/initialData.ts
@@ -1,28 +1,28 @@
-
 export const initUserData = {
-    id: "",
-    name: "",
-    phoneNumber: "",
-    email: ""
-}
+  id: "",
+  name: "",
+  phoneNumber: "",
+  email: "",
+};
 
 export const initCouponData = {
-    id: "",
-    value: "",
-    code: "",
-    type: "",
-    couponName: ""
-}
+  id: "",
+  value: "",
+  code: "",
+  type: "",
+  couponName: "",
+};
 
 export const initCourseData = {
-    title: "",
-    cover_url: ""
-}
+  id: "",
+  title: "",
+  cover_url: "",
+};
 
 export const initOrderData = {
-    id: "",
-    originalPrice: null,
-    orderPrice: null,
-    status: null,
-    paidAt: "",
-}
+  id: "",
+  originalPrice: null,
+  orderPrice: null,
+  status: null,
+  paidAt: "",
+};

--- a/src/pages/student/order-page/service/type.ts
+++ b/src/pages/student/order-page/service/type.ts
@@ -1,102 +1,103 @@
 /** 訂單狀態類型 */
-export type OrderStatus = null | 'pending' | 'paid' | 'failed';
+export type OrderStatus = null | "pending" | "paid" | "failed";
 
 /** 課程資訊 */
 export type CourseInfo = {
-    title: string;
-    cover_url: string;
-    // price: number;
-}
+  title: string;
+  cover_url: string;
+  id: string;
+  // price: number;
+};
 /** 學生資訊 */
 export type UserInfo = {
-    id: string;
-    name: string;
-    phoneNumber: string;
-    email: string;
-}
+  id: string;
+  name: string;
+  phoneNumber: string;
+  email: string;
+};
 
 /** 折扣碼資訊 */
 export type CouponInfo = {
-    id: string;
-    value: string;
-    code: string;
-    type: string;
-    couponName: string;
-}
+  id: string;
+  value: string;
+  code: string;
+  type: string;
+  couponName: string;
+};
 
 /** 訂單資訊 */
 type OrderInfo = {
-    /** 課程卡片的原價 */
-    originalPrice: number;
-    /** 訂單總計價格 */
-    orderPrice: number;
-}
+  /** 課程卡片的原價 */
+  originalPrice: number;
+  /** 訂單總計價格 */
+  orderPrice: number;
+};
 
 /** 訂單預覽 - 回傳資料 */
 export type OrderPreviewResponseModel = {
-    /** 課程卡片的原價 */
-    originalPrice: number | null;
-    /** 訂單總計價格 */
-    orderPrice: number | null;
-    /** 訂單狀態 */
-    status: OrderStatus;
-    /** 課程資訊 */
-    course: CourseInfo;
-    /** 學生資訊 */
-    user: UserInfo;
-}
+  /** 課程卡片的原價 */
+  originalPrice: number | null;
+  /** 訂單總計價格 */
+  orderPrice: number | null;
+  /** 訂單狀態 */
+  status: OrderStatus;
+  /** 課程資訊 */
+  course: CourseInfo;
+  /** 學生資訊 */
+  user: UserInfo;
+};
 
 /** 使用折扣碼 - 回傳資料 */
 export type ApplyCouponResponseModel = {
-    coupon: CouponInfo;
-    order: OrderInfo;
-}
+  coupon: CouponInfo;
+  order: OrderInfo;
+};
 
 /** 取得訂單 - 回傳資料 */
 export type FetchOrderResponseModel = {
-    id: string;
-    /** 課程卡片的原價 */
-    originalPrice: number | null;
-    /** 訂單總計價格 */
-    orderPrice: number | null;
-    /** 訂單狀態 */
-    status: OrderStatus;
-    createdAt: string;
-    updatedAt: string;
-    paidAt: string;
-    course: CourseInfo;
-    coupon: CouponInfo;
-    user: UserInfo;
-}
+  id: string;
+  /** 課程卡片的原價 */
+  originalPrice: number | null;
+  /** 訂單總計價格 */
+  orderPrice: number | null;
+  /** 訂單狀態 */
+  status: OrderStatus;
+  createdAt: string;
+  updatedAt: string;
+  paidAt: string;
+  course: CourseInfo;
+  coupon: CouponInfo;
+  user: UserInfo;
+};
 
 /** 創建訂單 - 回傳資料 */
 export type CreateOrderResponseModel = {
-    id: string;
-    /** 課程卡片的原價 */
-    originalPrice: number | null;
-    /** 訂單總計價格 */
-    orderPrice: number | null;
-    /** 訂單狀態 */
-    status: OrderStatus;
-    createdAt: string;
-    course: CourseInfo;
-    coupon: CouponInfo;
-    user: UserInfo;
-}
+  id: string;
+  /** 課程卡片的原價 */
+  originalPrice: number | null;
+  /** 訂單總計價格 */
+  orderPrice: number | null;
+  /** 訂單狀態 */
+  status: OrderStatus;
+  createdAt: string;
+  course: CourseInfo;
+  coupon: CouponInfo;
+  user: UserInfo;
+};
 
 /** 訂單預覽 - 請求資料  */
 export type OrderPreviewRequestModel = {
-    courseId: string;
-}
+  courseId: string;
+};
 
 /** 驗證折扣碼 - 請求資料 */
 export type ApplyCouponRequestModel = {
-    couponCode: string;
-    originalPrice: number;
-}
+  couponCode: string;
+  originalPrice: number;
+};
 
 /** 建立訂單 - 請求資料 */
 export type CreateOrderRequestModel = {
-    courseId: string;
-    couponId: string;
-}
+  courseId: string;
+  couponId: string;
+};


### PR DESCRIPTION
### ✨ 新功能內容
- 結帳完成頁面增加按鈕
（左：繼續購買 右 ：依訂單狀態顯示不同：重新付款（待付款)/ 重新下單（付款失敗) / 開始觀看（付款成功）

<img width="880" alt="image" src="https://github.com/user-attachments/assets/3c52d19a-781a-4934-8f30-bc8a9108efb3" />

-修復結帳完成頁面課程縮圖顯示

-修復折扣金額.折扣碼名稱顯示
此頁原本僅顯示紅字折扣金額，調整成如設計稿樣式

### 📌 背景與目的
- 提升使用者體驗
- 修復bug https://github.com/ArvinYang1925/kaiso-meow-frontend/issues/64


---

### ✅ 自我測試檢查
- [ ] 功能流程跑通
- [ ] 與設計稿符合（若有）
- [ ] API 串接正確，資料更新正常
- [ ] 無多餘 console.log 或測試代碼

---

### 🔍 希望 Reviewer 協助確認：


-後端API 15有調整，**折扣碼顯示**部分可以等這邊PR過再驗證（或是後端使用fix/api15_couponformat 分支測試）
https://github.com/ArvinYang1925/kaiso-meow-backend/pull/88

-可連同訂單頁面一起驗證

---

### 🧪 測試方式

建議購買首頁9門課作為測試

可使用折扣碼：
<img width="883" alt="image" src="https://github.com/user-attachments/assets/01df3eca-ed03-45ab-bfc2-36976329f308" />

---



### 📅 備註
- 週末有空請幫忙 review，先感謝 🙇‍♀️
