### PR TITLE
refactor: 💡 調整結帳後"繼續購買"導到首頁後滾動至"強打課程"區塊

### DIFF
--- a/src/pages/student/checkout-page/CheckoutPage.tsx
+++ b/src/pages/student/checkout-page/CheckoutPage.tsx
@@ -31,7 +31,7 @@ const CheckoutPage = () => {
 
   // 繼續購買：跳轉到首頁
   const handleBackToHome = () => {
-    navigate(CLIENT_ROUTES.HOME);
+    navigate(`${CLIENT_ROUTES.HOME}#course-section`);
   };
 
   // 開始觀看 : 跳轉到我的學習頁面

--- a/src/pages/student/home-page/HomePage.tsx
+++ b/src/pages/student/home-page/HomePage.tsx
@@ -9,13 +9,27 @@ import NewsLetterComponent from "./components/NewsletterComponent";
 import decorationSvg from "@/assets/homepage/decoration.svg";
 import topLeftDecor from "@/assets/homepage/top-left-course-card.png";
 import bottomRightDecor from "@/assets/homepage/right-down-course-card.png";
+import { useLocation } from "react-router-dom";
+import { useEffect } from "react";
 
 export const HomePage: React.FC = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.hash) {
+      const target = document.querySelector(location.hash);
+      if (target) {
+        target.scrollIntoView({ behavior: "smooth" }); // 滑動到該區塊
+      }
+    }
+  }, [location]);
+  
   return (
     <>
       <BannerComponent />
       {/* 課程卡片區塊 */}
       <div
+        id="course-section" 
         className="py-24 course-card-section bg-slate-50"
         style={{
           backgroundImage: `url(${topLeftDecor}), url(${bottomRightDecor})`,


### PR DESCRIPTION
### ✨ 新功能內容

- 調整"繼續購買"按鈕，詳見影片


https://github.com/user-attachments/assets/555d8c4f-369b-4a88-b58e-c7c107a1c7fc



### 📌 背景與目的
- 提升使用者體驗

---

### ✅ 自我測試檢查
- [x] 功能流程跑通
- [ ] 與設計稿符合（若有）
- [x] API 串接正確，資料更新正常
- [x] 無多餘 console.log 或測試代碼

---

### 🔍 希望 Reviewer 協助確認：

-  根據功能有增加HomePage內容，可以協助確認此調整位置是否合適
或需至其他資料夾層底下建立獨立檔案?

---

### 🧪 測試方式
> 提供測試路徑與方式，讓 Reviewer 可以快速驗證：

- 登入學生帳號
- 到 `http://localhost:5173/checkout/:orderId` (替換成屬於該帳號的orderId) 頁
- 點選繼續購買
- 確認畫面滾動到"強打課程"

---

### 📅 備註
- 週末有空請幫忙 review，先感謝 🙇‍♀️
