### PR TITLE
fix: 🐛 課程列表不需使用準備中遮罩

### DIFF
--- a/src/pages/student/course-list-page/CourseListPage.tsx
+++ b/src/pages/student/course-list-page/CourseListPage.tsx
@@ -87,14 +87,6 @@ const AnimatedCourseCard: React.FC<AnimatedCourseCardProps> = ({
               transition={{ duration: 0.3 }}
             />
 
-            {/* 課程準備中覆蓋層 */}
-            {!course.isReady && (
-              <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-                <div className="bg-orange-200 text-orange-800 px-4 py-2 rounded-lg font-medium">
-                  課程準備中
-                </div>
-              </div>
-            )}
           </div>
         </CardHeader>
 
@@ -136,18 +128,13 @@ const AnimatedCourseCard: React.FC<AnimatedCourseCardProps> = ({
             </span>
             <Button
               variant="outline"
-              className={`bg-orange-500 text-white hover:bg-orange-600 hover:text-gray ${
-                !course.isReady ? "opacity-40 cursor-not-allowed" : ""
-              }`}
-              disabled={!course.isReady}
+              className="bg-orange-500 text-white hover:bg-orange-600 hover:text-gray"
               onClick={(e) => {
                 e.stopPropagation();
-                if (course.isReady) {
-                  navigate(`/course/${course.id}`);
-                }
+                navigate(`/course/${course.id}`);
               }}
             >
-              {course.isReady ? "查看詳情" : "課程準備中"}
+              查看詳情
             </Button>
           </motion.div>
         </CardContent>


### PR DESCRIPTION


### ✨ 新功能內容

去除“課程列表”準備中遮罩
延伸 #120 的修改

### 📌 背景與目的

目前課程列表：
![image](https://github.com/user-attachments/assets/84b53564-eefe-4e90-942f-96caa9f82bdf)


由於後端依照[issue94](https://github.com/ArvinYang1925/kaiso-meow-frontend/issues/94)
只有修改"我的學習"頁面API
“課程列表”頁面API維持原狀，且不能阻擋，因為原本邏輯就是要可以讓學生點選購買的


---

### ✅ 自我測試檢查
- [ ] 功能流程跑通
- [ ] 與設計稿符合（若有）
- [ ] API 串接正確，資料更新正常
- [ ] 無多餘 console.log 或測試代碼

---

### 🔍 希望 Reviewer 協助確認：

確認此還原符合原本設計風格

---

