### PR TITLE
fix: 🐛 update avator when chanege user name

### DIFF
--- a/src/pages/student/profile-page/ProfilePage.tsx
+++ b/src/pages/student/profile-page/ProfilePage.tsx
@@ -58,7 +58,6 @@ export default function ProfilePage() {
   };
 
   const handleUpdateFormData = async () => {
-    console.log('submit!!!!!')
     if (!validateProfile()) return;
 
     setIsLoading(true);
@@ -68,7 +67,6 @@ export default function ProfilePage() {
         phoneNumber: profile.phoneNumber,
       };
       const response = await updateProfile(data);
-      console.log("res", response)
       showCommonDialog({
         title: "儲存成功",
         description: response.status,

--- a/src/pages/student/profile-page/ProfilePage.tsx
+++ b/src/pages/student/profile-page/ProfilePage.tsx
@@ -58,6 +58,7 @@ export default function ProfilePage() {
   };
 
   const handleUpdateFormData = async () => {
+    console.log('submit!!!!!')
     if (!validateProfile()) return;
 
     setIsLoading(true);
@@ -67,6 +68,7 @@ export default function ProfilePage() {
         phoneNumber: profile.phoneNumber,
       };
       const response = await updateProfile(data);
+      console.log("res", response)
       showCommonDialog({
         title: "儲存成功",
         description: response.status,

--- a/src/pages/student/profile-page/profileStore.ts
+++ b/src/pages/student/profile-page/profileStore.ts
@@ -1,146 +1,165 @@
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
-import { fetchProfile, updateProfile, updatePassword } from './profile.service';
-import { toast } from '@/hooks/use-toast';
-import { ProfileModel, UpdateProfileModel, UpdateProfileResponseModel, PasswordModel, UpdatePasswordModel, UpdatePasswordResponseModel } from './types';
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { fetchProfile, updateProfile, updatePassword } from "./profile.service";
+import { toast } from "@/hooks/use-toast";
+import {
+  ProfileModel,
+  UpdateProfileModel,
+  UpdateProfileResponseModel,
+  PasswordModel,
+  UpdatePasswordModel,
+  UpdatePasswordResponseModel,
+} from "./types";
+import { useAuthStore } from "@/stores/authStore";
 
 interface ProfilePageState {
-    profile: ProfileModel;
-    password: PasswordModel;
-    isLoading: boolean;
-    isShowDialog: boolean;
+  profile: ProfileModel;
+  password: PasswordModel;
+  isLoading: boolean;
+  isShowDialog: boolean;
 }
 
 interface ProfilePageAction {
-    fetchProfile: () => Promise<void>;
-    updateProfile: (data: UpdateProfileModel) => Promise<UpdateProfileResponseModel>;
-    updatePassword: (data: UpdatePasswordModel) => Promise<UpdatePasswordResponseModel>
-    setIsLoading: (loading: boolean) => void;
-    setIsShowDialog: (isShowDialog: boolean) => void;
-    updateProfileFormData: (fields: Partial<ProfileModel>) => void;
-    updatePasswordFormData: (fields: Partial<PasswordModel>) => void;
-    resetStore: () => void;
+  fetchProfile: () => Promise<void>;
+  updateProfile: (
+    data: UpdateProfileModel
+  ) => Promise<UpdateProfileResponseModel>;
+  updatePassword: (
+    data: UpdatePasswordModel
+  ) => Promise<UpdatePasswordResponseModel>;
+  setIsLoading: (loading: boolean) => void;
+  setIsShowDialog: (isShowDialog: boolean) => void;
+  updateProfileFormData: (fields: Partial<ProfileModel>) => void;
+  updatePasswordFormData: (fields: Partial<PasswordModel>) => void;
+  resetStore: () => void;
 }
 
 const initialProfile: ProfileModel = {
-    id: '',
-    name: '',
-    phoneNumber: '',
-    email: '',
-}
+  id: "",
+  name: "",
+  phoneNumber: "",
+  email: "",
+};
 
 const initialPassword: PasswordModel = {
-    oldPassword: '',
-    newPassword: '',
-    confirmNewPassword: '',
-}
+  oldPassword: "",
+  newPassword: "",
+  confirmNewPassword: "",
+};
 
 export const useProfileStore = create<ProfilePageState & ProfilePageAction>()(
-    immer((set) => ({
-        profile: initialProfile,
-        password: initialPassword,
-        isLoading: false,
-        isShowDialog: false,
-        resetStore: () => {
-            set((state) => {
-                state.profile = initialProfile
-                state.password = initialPassword
-                state.isLoading = false
-                state.isShowDialog = false
-            })
-        },
-        fetchProfile: async () => {
-            set((state) => {
-                state.isLoading = true;
-            });
-            try {
-                const response = await fetchProfile();
-                set((state) => {
-                    state.profile = response.data;
-                });
-            } catch (error) {
-                console.error('Failed to fetch profile', error);
-                toast({
-                    variant: 'destructive',
-                    title: '載入失敗',
-                    description: '無法取得個人資料，請稍後再試。',
-                });
-            } finally {
-                set((state) => {
-                    state.isLoading = false;
-                });
-            }
-        },
-        updateProfile: async (formData: UpdateProfileModel) => {
-            set((state) => {
-                state.isLoading = true;
-            });
-            try {
-                const response = await updateProfile(formData);
-                const { status, data } = response
-                if (status == 'success') {
-                    // 更新成功後，更新本地狀態
-                    set((state) => {
-                        state.profile = data;
-                    });
-                }
-                return response;
-            } catch (error) {
-                console.error('Failed to save profile', error);
-                toast({
-                    variant: 'destructive',
-                    title: '儲存失敗',
-                    description: '無法儲存個人資料，請稍後再試。',
-                });
-                throw error; // 重新拋出錯誤，讓調用者可以處理
-            } finally {
-                set((state) => {
-                    state.isLoading = false;
-                });
-            }
-        },
-        updatePassword: async (data: UpdatePasswordModel) => {
-            set((state) => {
-                state.isLoading = true;
-            });
-            try {
-                const response = await updatePassword(data);
-                return response;
-            } catch (error) {
-                console.error('Failed to update', error);
-                toast({
-                    variant: 'destructive',
-                    title: '密碼變更失敗',
-                    description: '無法變更密碼，請稍後再試。',
-                });
-                throw error; // 重新拋出錯誤，讓調用者可以處理
-            } finally {
-                set((state) => {
-                    state.isLoading = false;
-                });
-            }
-        },
-        setIsLoading: (loading) => {
-            set((state) => {
-                state.isLoading = loading;
-            });
-        },
+  immer((set) => ({
+    profile: initialProfile,
+    password: initialPassword,
+    isLoading: false,
+    isShowDialog: false,
+    resetStore: () => {
+      set((state) => {
+        state.profile = initialProfile;
+        state.password = initialPassword;
+        state.isLoading = false;
+        state.isShowDialog = false;
+      });
+    },
+    fetchProfile: async () => {
+      set((state) => {
+        state.isLoading = true;
+      });
+      try {
+        const response = await fetchProfile();
+        set((state) => {
+          state.profile = response.data;
+        });
+      } catch (error) {
+        console.error("Failed to fetch profile", error);
+        toast({
+          variant: "destructive",
+          title: "載入失敗",
+          description: "無法取得個人資料，請稍後再試。",
+        });
+      } finally {
+        set((state) => {
+          state.isLoading = false;
+        });
+      }
+    },
+    updateProfile: async (formData: UpdateProfileModel) => {
+      set((state) => {
+        state.isLoading = true;
+      });
+      try {
+        const response = await updateProfile(formData);
+        const { status, data } = response;
+        if (status == "success" && data) {
+          // 更新成功後，更新本地狀態
+          set((state) => {
+            state.profile = data;
+          });
 
-        setIsShowDialog: (isShowDialog) => {
-            set((state) => {
-                state.isShowDialog = isShowDialog;
-            });
-        },
+          // 同時更新 authStore 中的 userInfo（這會自動更新 localStorage）
+          const { updateUserInfo } = useAuthStore.getState();
+          updateUserInfo({
+            name: data.name,
+            phoneNumber: data.phoneNumber,
+          });
+        }
+        return response;
+      } catch (error) {
+        console.error("Failed to save profile", error);
+        toast({
+          variant: "destructive",
+          title: "儲存失敗",
+          description: "無法儲存個人資料，請稍後再試。",
+        });
+        throw error; // 重新拋出錯誤，讓調用者可以處理
+      } finally {
+        set((state) => {
+          state.isLoading = false;
+        });
+      }
+    },
+    updatePassword: async (data: UpdatePasswordModel) => {
+      set((state) => {
+        state.isLoading = true;
+      });
+      try {
+        const response = await updatePassword(data);
+        return response;
+      } catch (error) {
+        console.error("Failed to update", error);
+        toast({
+          variant: "destructive",
+          title: "密碼變更失敗",
+          description: "無法變更密碼，請稍後再試。",
+        });
+        throw error; // 重新拋出錯誤，讓調用者可以處理
+      } finally {
+        set((state) => {
+          state.isLoading = false;
+        });
+      }
+    },
+    setIsLoading: (loading) => {
+      set((state) => {
+        state.isLoading = loading;
+      });
+    },
 
-        updateProfileFormData: (fields) => {
-            set((state) => {
-                Object.assign(state.profile, fields);
-            });
-        },
-        updatePasswordFormData: (fields) => {
-            set((state) => {
-                Object.assign(state.password, fields);
-            });
-        },
-    }))
+    setIsShowDialog: (isShowDialog) => {
+      set((state) => {
+        state.isShowDialog = isShowDialog;
+      });
+    },
+
+    updateProfileFormData: (fields) => {
+      set((state) => {
+        Object.assign(state.profile, fields);
+      });
+    },
+    updatePasswordFormData: (fields) => {
+      set((state) => {
+        Object.assign(state.password, fields);
+      });
+    },
+  }))
 );

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,7 +1,18 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
-import { loginUser, logoutUser, registerUser, sendPasswordForgotLetter } from "@/services/auth.service";
-import { LoginFormData, RegisterFormData, LoginResponseData, PasswordForgotFormData, LoginResponse } from "@/services/types";
+import {
+  loginUser,
+  logoutUser,
+  registerUser,
+  sendPasswordForgotLetter,
+} from "@/services/auth.service";
+import {
+  LoginFormData,
+  RegisterFormData,
+  LoginResponseData,
+  PasswordForgotFormData,
+  LoginResponse,
+} from "@/services/types";
 import { Role } from "@/lib/enum";
 
 interface AuthState {
@@ -16,12 +27,17 @@ interface AuthState {
 interface AuthActions {
   login: (formData: LoginFormData) => Promise<LoginResponse>;
   logout: () => void;
-  register: (formData: RegisterFormData) => Promise<{ success: boolean; message?: string }>;
-  sendPasswordForgotLetter: (formData: PasswordForgotFormData) => Promise<{ status: string; message?: string }>;
+  register: (
+    formData: RegisterFormData
+  ) => Promise<{ success: boolean; message?: string }>;
+  sendPasswordForgotLetter: (
+    formData: PasswordForgotFormData
+  ) => Promise<{ status: string; message?: string }>;
   getRole: () => Role | null;
   getHomeRedirect: () => string;
   clearError: () => void;
   setIsShowPasswordForgotForm: (isShow: boolean) => void;
+  updateUserInfo: (updates: Partial<LoginResponseData>) => void;
 }
 
 export const useAuthStore = create<AuthState & AuthActions>()(
@@ -80,7 +96,7 @@ export const useAuthStore = create<AuthState & AuthActions>()(
         state.isLoading = true;
         state.errorMsg = null;
       });
-
+      ßß;
       try {
         const response = await registerUser(formData);
         const { token, userInfo } = response.data.data;
@@ -132,7 +148,6 @@ export const useAuthStore = create<AuthState & AuthActions>()(
       }
     },
 
-
     getRole: () => {
       return get().userInfo?.role || null;
     },
@@ -153,7 +168,19 @@ export const useAuthStore = create<AuthState & AuthActions>()(
       set((state) => {
         state.isShowPasswordForgottenForm = isShow;
       });
-    }
+    },
+    updateUserInfo: (updates: Partial<LoginResponseData>) => {
+      console.log("update");
+      set((state) => {
+        if (state.userInfo) {
+          // 更新 state 中的 userInfo
+          Object.assign(state.userInfo, updates);
+
+          // 同時更新 localStorage
+          localStorage.setItem("userInfo", JSON.stringify(state.userInfo));
+        }
+      });
+    },
   }))
 );
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -96,7 +96,7 @@ export const useAuthStore = create<AuthState & AuthActions>()(
         state.isLoading = true;
         state.errorMsg = null;
       });
-      ßß;
+
       try {
         const response = await registerUser(formData);
         const { token, userInfo } = response.data.data;


### PR DESCRIPTION
🔄 同步個人資料更新至 localStorage 和 Header Avatar

✨ 新功能內容
	•	新增了個人資料更新後自動同步 localStorage 的功能
	•	新增了 authStore.updateUserInfo() 方法用於統一管理用戶資訊更新
	•	修改了 profileStore.updateProfile() 在更新成功後自動同步到 auth store

📌 背景與目的
	•	**問題**：用戶在個人資料頁面更新姓名後，Header 的 Avatar 顯示名字首字母沒有即時更新
	•	**原因**：個人資料更新只更新了 profile store，但沒有同步更新 localStorage 中的 userInfo
	•	**目的**：確保用戶資料在各個 store 和 localStorage 之間保持一致性，提升用戶體驗

---

✅ 自我測試檢查
	•	[x] 功能流程跑通
	•	[x] 與設計稿符合（若有）
	•	[x] API 串接正確，資料更新正常
	•	[x] 無多餘 console.log 或測試代碼

---

🔍 希望 Reviewer 協助確認：
	•	資料流是否清楚：profileStore → authStore → localStorage → Header
	•	是否有其他地方也需要類似的同步機制
	•	型別定義是否正確（updateUserInfo 的參數型別）

---

🧪 測試方式
提供測試路徑與方式，讓 Reviewer 可以快速驗證：

	1.	**登入系統**，觀察 Header 右上角 Avatar 顯示的姓名首字母
	2.	*前往個人資料頁* /profile
	3.	**點選編輯按鈕**，修改姓名（例如：從 "張三" 改為 "李四"）
	4.	**點選儲存**，確認出現「儲存成功」提示
	5.	*檢查 Header Avatar* 是否立即更新為新姓名首字母（"李" → "李"）
	6.	**重新整理頁面**，確認 Avatar 仍顯示正確的首字母
	7.	*開發者工具檢查* localStorage 中的 userInfo.name 是否已更新

**預期結果**：
	•	✅ 儲存成功後 Header Avatar 立即更新
	•	✅ localStorage 中的 userInfo 同步更新
	•	✅ 重新整理後資料保持一致

---

📝 技術細節

*修改檔案：*
	•	authStore.ts：新增 updateUserInfo 方法
	•	profileStore.ts：修改 updateProfile 方法加入同步邏輯

*資料流程：*
用戶更新個人資料 
→ profileStore.updateProfile() 
→ API 更新成功 
→ authStore.updateUserInfo() 
→ 更新 localStorage 
→ Header.userName 自動反映變化

---

🙋 Reviewer 指派
	•	@frontend-team（資料流與狀態管理）
	•	@ux-team（用戶體驗確認）

---

📅 備註
	•	這是一個用戶體驗優化，建議優先 review 🙇‍♀️
	•	未來如有其他用戶資料更新場景，可參考此模式實作