### PR TITLE
fix: 調整 issue #140

### DIFF
--- a/src/components/common/CommonDialog.tsx
+++ b/src/components/common/CommonDialog.tsx
@@ -26,7 +26,7 @@ export function CommonDialog() {
   return (
     <Dialog open={isShowDialog} onOpenChange={setIsShowDialog}>
       <DialogTitle></DialogTitle>
-      <DialogContent className="text-center py-10">
+      <DialogContent className="text-center py-10 px-4 sm:px-8 max-w-[95vw] sm:max-w-lg rounded-lg">
         <div className="flex flex-col items-center gap-4">
           <Icon size={56} className={`${iconColor}`} />
           <h2 className="text-3xl font-semibold">{titleText}</h2>
@@ -39,7 +39,7 @@ export function CommonDialog() {
         <DialogFooter className="mt-4 flex justify-center">
           <Button
             onClick={handleClose}
-            className="bg-orange-500 hover:bg-orange-600 w-[200px]"
+            className="bg-orange-500 hover:bg-orange-600 w-full md:w-[200px]"
           >
             關閉
           </Button>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -88,7 +88,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      "p-2 h-20 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
       className
     )}
     {...props}

--- a/src/pages/student/profile-page/ProfilePage.tsx
+++ b/src/pages/student/profile-page/ProfilePage.tsx
@@ -80,7 +80,7 @@ export default function ProfilePage() {
 
   return (
     <>
-      <div className="w-full md:w-[1200px] mx-auto px-8 mb-16">
+      <div className="w-full md:w-[760px] mx-auto px-8 mb-16">
         <h1 className="text-start text-3xl mt-16 font-bold mb-8">個人資料</h1>
         <Card className="w-full p-6 border-none">
           <CardHeader></CardHeader>
@@ -132,10 +132,10 @@ export default function ProfilePage() {
               <ChangePasswordDialog />
             </div>
 
-            <div className="w-full flex justify-end space-x-4 pt-4">
+            <div className="flex gap-2">
               {!isEditing ? (
                 <Button
-                  className="w-full md:w-[25%] bg-orange-500 hover:bg-orange-600"
+                  className="w-full bg-orange-500 hover:bg-orange-600"
                   onClick={() => setIsEditing(true)}
                 >
                   編輯
@@ -143,14 +143,14 @@ export default function ProfilePage() {
               ) : (
                 <>
                   <Button
-                    className="w-full md:w-[25%]"
+                    className="w-full"
                     variant="outline"
                     onClick={() => setIsEditing(false)}
                   >
                     取消
                   </Button>
                   <Button
-                    className="w-full md:w-[25%] bg-orange-500 hover:bg-orange-600"
+                    className="w-full bg-orange-500 hover:bg-orange-600"
                     onClick={handleUpdateFormData}
                     disabled={isLoading}
                   >

--- a/src/pages/student/profile-page/components/ChangePasswordDialog.tsx
+++ b/src/pages/student/profile-page/components/ChangePasswordDialog.tsx
@@ -109,14 +109,14 @@ export default function ChangePasswordDialog() {
 
           <DialogFooter className="flex justify-end">
             <DialogClose asChild>
-              <Button variant="ghost" onClick={() => setIsShowDialog(false)}>
+              <Button variant="ghost" className="border border-slate-200" onClick={() => setIsShowDialog(false)}>
                 取消
               </Button>
             </DialogClose>
             <Button
               type="submit"
               disabled={isLoading}
-              className="bg-orange-500 hover:bg-orange-600"
+              className="bg-orange-500 hover:bg-orange-600 mb-2"
             >
               設定密碼
             </Button>

--- a/src/pages/student/profile-page/components/ChangePasswordDialog.tsx
+++ b/src/pages/student/profile-page/components/ChangePasswordDialog.tsx
@@ -15,6 +15,7 @@ import { PasswordModel } from "../types";
 import { updatePassword } from "../profile.service";
 import { useDialogStore } from "@/stores/commonDialogStore";
 import { handleErrorMessageDialog } from "@/lib/helper";
+import { useNavigate } from "react-router-dom";
 
 export default function ChangePasswordDialog() {
   const {
@@ -27,6 +28,7 @@ export default function ChangePasswordDialog() {
 
   const { isLoading, isShowDialog, setIsShowDialog } = useProfileStore();
   const { showCommonDialog } = useDialogStore();
+  const navigate = useNavigate();
 
   const onSubmit = async (data: PasswordModel) => {
     if (data.newPassword !== data.confirmNewPassword) {
@@ -39,6 +41,8 @@ export default function ChangePasswordDialog() {
         type: "success",
         message: "密碼變更成功",
       });
+      setIsShowDialog(false);
+      navigate("/");
     } catch (error) {
       handleErrorMessageDialog(error);
     }
@@ -109,7 +113,11 @@ export default function ChangePasswordDialog() {
 
           <DialogFooter className="flex justify-end">
             <DialogClose asChild>
-              <Button variant="ghost" className="border border-slate-200" onClick={() => setIsShowDialog(false)}>
+              <Button
+                variant="ghost"
+                className="border border-slate-200"
+                onClick={() => setIsShowDialog(false)}
+              >
                 取消
               </Button>
             </DialogClose>


### PR DESCRIPTION
### ✨ 內容

重設密碼的錯誤訊息，直接帶後端回的訊息
table 資料的 RWD，欄位高度不一致 (6/22之後會去修改的項目)
使用者更新名稱，localstorage 的使用者名稱即時更新
套用優惠券的彈窗 (手機版)
重設密碼成功之後，可以導回首頁
刪除章節 (6/30 新增)


剩下：
首頁 RWD 專家建議尚未處理